### PR TITLE
Adds ... to long extension names.

### DIFF
--- a/src/vs/workbench/parts/extensions/electron-browser/media/extensionsViewlet.css
+++ b/src/vs/workbench/parts/extensions/electron-browser/media/extensionsViewlet.css
@@ -85,11 +85,14 @@
 	flex-wrap: wrap;
 	overflow: hidden;
 	flex: 1;
+	min-width: 0;
 }
 
 .extensions-viewlet > .extensions .extension > .details > .header-container > .header > .name {
 	font-weight: bold;
-	min-width: fit-content;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	overflow: hidden;
 }
 
 .extensions-viewlet > .extensions .extension > .details > .header-container > .header > .version {


### PR DESCRIPTION
As the names of the extensions are under a `flex` box we should force the `...` on its `children`, as `text-overflow` applies to `block` elements. 